### PR TITLE
Fix the Navbar mobile image scaling

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -49,11 +49,9 @@
 		<header>
 			<div class="container">
 				<div class="nav-container">
-					<div class="company-name">
-						<a href="{{ site.baseurl }}/">
-							<img alt="UNDM Logo" src="../images/logos/flameLogo.png" width="50%" height="auto">
-						</a>
-					</div>
+					<a href="{{ site.baseurl }}/">
+						<img alt="UNDM Logo" src="../images/logos/flameLogo.png" width="50%" height="auto" style="max-width: 25px;">
+					</a>
 					{% include navigation.html %}
 				</div>
 			</div>


### PR DESCRIPTION
Eliminated an extra div and set a max-width on the brand image to avoid crazy scaling. This looks fine on my desktop browser when shrunk down, but it should still be tested on mobile.