### PR TITLE
Fixed unclickable logo issue

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -49,7 +49,7 @@
 		<header>
 			<div class="container">
 				<div class="nav-container">
-					<a href="{{ site.baseurl }}/">
+					<a href="{{ site.baseurl }}/" style="position: relative; z-index: 1;">
 						<img alt="UNDM Logo" src="../images/logos/flame_one_line.png" width="25%" height="auto" style="max-width: 500px;">
 					</a>
 					{% include navigation.html %}


### PR DESCRIPTION
Logo's alt tag that contained the hyperlink existed underneath the left side of the navbar which is invisible, so you couldn't click under that element.